### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Continuation] based non-blocking, asynchronous, single threaded web server. Inspired by [Swirl] (sugar for [Tornado]),
 [Tornado] itself and [Deft]
 
-#Usage:
+# Usage:
     object ExampleHandler extends RequestHandler {
 
       @Asynchronous
@@ -27,11 +27,11 @@
 
     }
 
-#Disclaimer
+# Disclaimer
 Loft is far from (production) ready. The example above (ExampleHandler) is the proposed syntax for doing asynchronous calls.
 The initial plan for Loft is to adopt as much as possible from the [facebook/tornado] master branch.
  
-#Requirements
+# Requirements
 Java >= 1.5   
 Scala >= 2.8.0 (for loft developers: enable Scala continuation plugin (-P:continuations:enable))
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
